### PR TITLE
Fixed the issue with incorrect mapping for float style

### DIFF
--- a/src/glamor.re
+++ b/src/glamor.re
@@ -143,7 +143,7 @@ let elevation v => Property "elevation" v;
 
 let emptyCells v => Property "emptyCells" v;
 
-let cssFloat v => Property "cssFloat" v;
+let cssFloat v => Property "float" v;
 
 let font v => Property "font" v;
 


### PR DESCRIPTION
Currently cssFloat is produced on the html as css-float, which doesn't exist. This PR contains the fix for it.