### PR TITLE
Fix keyframes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Define animation keyframes:
 
 ```reason
 let bounce = Glamor.keyframes([
-  ("0%": [transform("scale(0.1)"), opacity("0")]),
-  ("60%": [transform("scale(1.2)"), opacity("1")]),
-  ("100%": [transform("scale(1)")])
+  ("0%", [transform("scale(0.1)"), opacity("0")]),
+  ("60%", [transform("scale(1.2)"), opacity("1")]),
+  ("100%", [transform("scale(1)")])
 ]);
 let styles = css([
     animationName(bounce),


### PR DESCRIPTION
Hey, I've noticed a typo in `keyframes` examples. There are colons `:` instead of commas `,`